### PR TITLE
Implement build pipeline

### DIFF
--- a/bats.toml
+++ b/bats.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bats-poc"
 kind = "bin"
+unsafe = true
 
 [dependencies]
 "builder" = ""


### PR DESCRIPTION
## Summary
- Add full build pipeline (`do_build()`) that preprocesses deps and binaries, runs patsopt, cc, and links the final binary
- Add `$UNSAFE` C helpers for byte-level ops and file writing to bypass ATS2 type constraints
- Add helper functions: `put_lit`/`bput`, `print_borrow`, `run_sh`, `write_file_from_builder`, `preprocess_one`, `str_to_path_arr`
- Enable `unsafe = true` in bats.toml
- Wire `build` CLI command to the pipeline

## Test plan
- [x] `bats check` passes (type-checking via Rust bats)
- [x] `bats build` succeeds (full compilation via Rust bats)
- [x] Built binary `bats-poc check` works (self-check via patsopt)
- [x] Built binary `bats-poc build` runs full pipeline (preprocess, patsopt, cc, link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)