### PR TITLE
Auto-install ATS2 toolchain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,11 @@ bats-poc must be:
 
 ## Build & Test
 
+Only use bats-poc to build bats-poc. Never use the Rust bats.
+
 ```bash
-PATSHOME=~/.bats/ats2 dist/debug/bats-poc build   # build self
-bats --run-in /home/moshez/src/bats-lang/bats-poc build --repository /home/moshez/src/bats-lang/repository-prototype
-bats --run-in /home/moshez/src/bats-lang/bats-poc check --repository /home/moshez/src/bats-lang/repository-prototype
+dist/debug/bats-poc check --repository /home/moshez/src/bats-lang/repository-prototype
+dist/debug/bats-poc build --repository /home/moshez/src/bats-lang/repository-prototype
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary

- Auto-detect and install ATS2 to ~/.bats/ats2/ (matching Rust bats behavior)
- No PATSHOME env var needed
- Downloads from GitHub, builds from C bootstrap if missing

## Test plan

- [x] `bats-poc check` works without PATSHOME set
- [x] Self-hosting works without PATSHOME

🤖 Generated with [Claude Code](https://claude.com/claude-code)