### PR TITLE
CI: upload --to-c output as artifact

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,3 +45,13 @@ jobs:
       - name: bats build
         run: |
           ~/bootstrap/target/release/bats build --repository ~/repository
+
+      - name: bats build --to-c
+        run: |
+          ~/bootstrap/target/release/bats build --to-c dist/c --repository ~/repository
+
+      - name: Upload C output
+        uses: actions/upload-artifact@v4
+        with:
+          name: bats-c
+          path: dist/c/

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: bats build --to-c
         run: |
-          ~/bootstrap/target/release/bats build --to-c dist/c --repository ~/repository
+          dist/debug/bats build --to-c dist/c --repository ~/repository
 
       - name: Upload C output
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- After the normal build step, runs `bats build --to-c dist/c` to generate C files + Makefile
- Uploads the output as a zip artifact named `bats-c` via `actions/upload-artifact@v4`

## Test plan
- [ ] CI passes and artifact appears on the workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)