### PR TITLE
Reject fun without metric and #pub prfun without primplement

### DIFF
--- a/src/lexer.bats
+++ b/src/lexer.bats
@@ -821,7 +821,7 @@ fun lex_main {l:agz}{n:pos}{fuel:nat} .<fuel>.
       val span_kind =
         if is_prfun || is_prfn then let
           val kw_len = if is_prfun then 5 else 4
-          val name_pos = _skip_to_name(src, contents_start + kw_len, max, 256)
+          val name_pos = _skip_to_name(src, $AR.add_int_int(contents_start, kw_len), max, 256)
           val name_end = skip_ident(src, name_pos, max, 4096)
           val name_len = name_end - name_pos
         in


### PR DESCRIPTION
## Summary

Two safety checks restored from the old Rust compiler:

1. **fun without termination metric**: `fun` without `.<metric>.` allows non-terminating recursion. Use `fn` for non-recursive functions or add a termination metric.

2. **#pub prfun/prfn without primplement**: A public proof function declaration without a corresponding `primplement` is unsound. If `primplement` exists in the same file, it's safe.

Both are emitted as span kind 5 (unsafe_construct) when detected.

## Test plan

- [ ] `bats check` passes (compiler uses `fun` with metrics everywhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)