### PR TITLE
Fix: stop passthrough scanner at unsafe keywords

### DIFF
--- a/src/lexer.bats
+++ b/src/lexer.bats
@@ -764,6 +764,12 @@ fun lex_passthrough_scan {l:agz}{n:pos}{fuel:nat} .<fuel>.
       (looking_at_pub(src, pos, max) || looking_at_use(src, pos, max) ||
        looking_at_target(src, pos, max)) then pos
     else if $AR.eq_int_int(b, 36) && is_ident_start(b1) then pos
+    (* Stop at unsafe keywords so lex_main can detect them *)
+    else if looking_at_castfn(src, pos, max) then pos
+    else if looking_at_praxi(src, pos, max) then pos
+    else if looking_at_extern(src, pos, max) then pos
+    else if looking_at_assume(src, pos, max) then pos
+    else if looking_at_fun(src, pos, max) then pos
     else lex_passthrough_scan(src, pos + 1, src_len, max, fuel - 1)
   end
 


### PR DESCRIPTION
## Summary

The passthrough scanner was consuming `castfn`, `extern`, `assume`, `praxi`, `fun` as passthrough text, so `lex_main` never detected them as unsafe constructs. Added stop conditions for these keywords so the main lex loop can create kind 5 spans for them.

Without this fix, unsafe constructs in library source files were silently passed through despite the enforcement added in PR #45.

## Test plan

- [ ] `bats check` passes on bats itself
- [ ] `bats build` on a safe package with `castfn` outside `\$UNSAFE` → error

🤖 Generated with [Claude Code](https://claude.com/claude-code)