### PR TITLE
Fix find_end_kw depth, re-enable strict enforcement

### DIFF
--- a/src/emitter.bats
+++ b/src/emitter.bats
@@ -388,26 +388,13 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
       in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
                     sats, dats, build_target, is_unsafe, errors + 1, fuel - 1) end
 
-    (* kind=5: unsafe_construct outside $UNSAFE block *)
-    else if $AR.eq_int_int(kind, 5) then
-      if $AR.gt_int_int(is_unsafe, 0) then let
-        (* unsafe package: emit as-is *)
-        val fuel2 = $AR.checked_nat(se - ss + 1)
-        val () = (if $AR.eq_int_int(dest, 0) || $AR.eq_int_int(dest, 2) then
-                    emit_range(src, ss, se, src_max, dats, fuel2)
-                  else ())
-        val () = (if $AR.eq_int_int(dest, 1) || $AR.eq_int_int(dest, 2) then
-                    emit_range(src, ss, se, src_max, sats, fuel2)
-                  else ())
-      in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors, fuel - 1) end
-      else let
-        (* safe package: error *)
-        val () = println! ("error: unsafe construct at line ", _byte_to_line(src, ss, src_max), " column ", _byte_to_col(src, ss, src_max), " outside $UNSAFE block")
-        val () = emit_blanks(src, ss, se, src_max, dats)
-        val () = emit_blanks(src, ss, se, src_max, sats)
-      in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors + 1, fuel - 1) end
+    (* kind=5: unsafe_construct outside $UNSAFE block — always error *)
+    else if $AR.eq_int_int(kind, 5) then let
+      val () = println! ("error: unsafe construct at line ", _byte_to_line(src, ss, src_max), " column ", _byte_to_col(src, ss, src_max), " outside $UNSAFE block")
+      val () = emit_blanks(src, ss, se, src_max, dats)
+      val () = emit_blanks(src, ss, se, src_max, sats)
+    in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
+                  sats, dats, build_target, is_unsafe, errors + 1, fuel - 1) end
 
     (* kind=6: extcode_block - emit as-is to dats *)
     else if $AR.eq_int_int(kind, 6) then let
@@ -445,24 +432,13 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
                   sats, dats, build_target, is_unsafe, errors, fuel - 1) end
 
-    (* kind=9: restricted_keyword — same as kind 5 *)
-    else if $AR.eq_int_int(kind, 9) then
-      if $AR.gt_int_int(is_unsafe, 0) then let
-        val fuel2 = $AR.checked_nat(se - ss + 1)
-        val () = (if $AR.eq_int_int(dest, 0) || $AR.eq_int_int(dest, 2) then
-                    emit_range(src, ss, se, src_max, dats, fuel2)
-                  else ())
-        val () = (if $AR.eq_int_int(dest, 1) || $AR.eq_int_int(dest, 2) then
-                    emit_range(src, ss, se, src_max, sats, fuel2)
-                  else ())
-      in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors, fuel - 1) end
-      else let
-        val () = println! ("error: unsafe construct at line ", _byte_to_line(src, ss, src_max), " column ", _byte_to_col(src, ss, src_max), " outside $UNSAFE block")
-        val () = emit_blanks(src, ss, se, src_max, dats)
-        val () = emit_blanks(src, ss, se, src_max, sats)
-      in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors + 1, fuel - 1) end
+    (* kind=9: restricted_keyword — same as kind 5, always error *)
+    else if $AR.eq_int_int(kind, 9) then let
+      val () = println! ("error: unsafe construct at line ", _byte_to_line(src, ss, src_max), " column ", _byte_to_col(src, ss, src_max), " outside $UNSAFE block")
+      val () = emit_blanks(src, ss, se, src_max, dats)
+      val () = emit_blanks(src, ss, se, src_max, sats)
+    in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
+                  sats, dats, build_target, is_unsafe, errors + 1, fuel - 1) end
 
     (* kind=10: unittest_run - emit contents in test mode, blank otherwise *)
     else if $AR.eq_int_int(kind, 10) then let

--- a/src/lexer.bats
+++ b/src/lexer.bats
@@ -253,6 +253,22 @@ fn looking_at_extkind {l:agz}{n:pos}
   $AR.eq_int_int($S.borrow_byte(src, pos + 7, max), 100) &&
   is_kw_boundary(src, pos + 8, max)
 
+(* "mac#" = 109,97,99,35 — C function binding *)
+fn looking_at_mac_hash {l:agz}{n:pos}
+  (src: !$A.borrow(byte, l, n), pos: int, max: int n): bool =
+  $AR.eq_int_int($S.borrow_byte(src, pos, max), 109) &&
+  $AR.eq_int_int($S.borrow_byte(src, pos + 1, max), 97) &&
+  $AR.eq_int_int($S.borrow_byte(src, pos + 2, max), 99) &&
+  $AR.eq_int_int($S.borrow_byte(src, pos + 3, max), 35)
+
+(* "ext#" = 101,120,116,35 — WASM export binding *)
+fn looking_at_ext_hash {l:agz}{n:pos}
+  (src: !$A.borrow(byte, l, n), pos: int, max: int n): bool =
+  $AR.eq_int_int($S.borrow_byte(src, pos, max), 101) &&
+  $AR.eq_int_int($S.borrow_byte(src, pos + 1, max), 120) &&
+  $AR.eq_int_int($S.borrow_byte(src, pos + 2, max), 116) &&
+  $AR.eq_int_int($S.borrow_byte(src, pos + 3, max), 35)
+
 (* "fun" = 102,117,110 — only unsafe WITHOUT termination metric *)
 fn looking_at_fun {l:agz}{n:pos}
   (src: !$A.borrow(byte, l, n), pos: int, max: int n): bool =
@@ -701,7 +717,7 @@ in
   in
     if looking_at_begin(src, p0, max) then let
       val contents_start = p0 + 5
-      val end_pos = find_end_kw(src, contents_start, src_len, max, 0, $AR.checked_nat(src_len))
+      val end_pos = find_end_kw(src, contents_start, src_len, max, 1, $AR.checked_nat(src_len))
       val ep = (if end_pos < src_len then end_pos + 3 else end_pos): int
       val () = put_span(spans, 4, 0, start, ep, contents_start, end_pos, 0, 0)
     in @(ep, count + 1, true) end
@@ -725,7 +741,7 @@ in
   in
     if looking_at_begin(src, p1, max) then let
       val contents_start = p1 + 5
-      val end_pos = find_end_kw(src, contents_start, src_len, max, 0, $AR.checked_nat(src_len))
+      val end_pos = find_end_kw(src, contents_start, src_len, max, 1, $AR.checked_nat(src_len))
       val ep = (if end_pos < src_len then end_pos + 3 else end_pos): int
       val () = put_span(spans, 10, 0, start, ep, contents_start, end_pos, 0, 0)
     in @(ep, count + 1, true) end
@@ -752,7 +768,7 @@ in
   if looking_at_begin(src, p1, max) then let
     (* Block form: find matching end, store content range *)
     val contents_start = p1 + 5
-    val end_pos = find_end_kw(src, contents_start, src_len, max, 0, $AR.checked_nat(src_len))
+    val end_pos = find_end_kw(src, contents_start, src_len, max, 1, $AR.checked_nat(src_len))
     val ep = (if end_pos < src_len then end_pos + 3 else end_pos): int
     (* kind=11: target_block. aux1=target(0=native,1=wasm), aux2/aux3=content range *)
     val () = put_span(spans, 11, 0, start, ep, target, contents_start, end_pos, 0)


### PR DESCRIPTION
## Summary

Two changes:

1. **find_end_kw starts at depth 1**: Inner let...end and local...end
   blocks no longer match at the same depth as the outer $UNSAFE begin...end.
   This allows wrapping function bodies in $UNSAFE blocks.

2. **Strict enforcement re-enabled**: Kind 5 spans (unsafe constructs outside
   $UNSAFE blocks) are always errors, even in unsafe=true packages. The
   relaxation is removed.

## Test plan

- [x] bats check passes (compiler has no $UNSAFE blocks)
- [ ] Unsafe packages need restructuring to put all constructs inside blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)