### PR TITLE
Fix find_end_kw: match end at depth 1

### DIFF
--- a/src/lexer.bats
+++ b/src/lexer.bats
@@ -692,7 +692,7 @@ fun find_end_kw {l:agz}{n:pos}{fuel:nat} .<fuel>.
   if fuel <= 0 then src_len
   else if pos >= src_len then src_len
   else if looking_at_end(src, pos, max) then
-    (if depth <= 0 then pos
+    (if depth <= 1 then pos
      else find_end_kw(src, pos + 3, src_len, max, depth - 1, fuel - 1))
   else if looking_at_begin(src, pos, max) then
     find_end_kw(src, pos + 5, src_len, max, depth + 1, fuel - 1)


### PR DESCRIPTION
## Summary
- Fix `find_end_kw` to match `end` when depth reaches 1, not 0
- The initial depth of 1 (set for `local` block handling) meant the first `end` was skipped, requiring a second `end` to match
- This caused `$UNSAFE begin...end` blocks to consume the rest of the file, masking safety enforcement

## Test plan
- [ ] CI passes (bats check + bats build)
- [ ] After merge, update array/file packages to properly wrap all unsafe constructs in `$UNSAFE begin...end` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)