### PR TITLE
Fix: recursively lex #target block content

### DIFF
--- a/src/emitter.bats
+++ b/src/emitter.bats
@@ -312,7 +312,8 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
    spans: !$A.borrow(byte, lp, np), span_max: int np,
    span_count: int, idx: int,
    sats: !$B.builder, dats: !$B.builder,
-   build_target: int, is_unsafe: int, errors: int, fuel: int fuel): int =
+   build_target: int, is_unsafe: int, errors: int,
+   skip_target: int, fuel: int fuel): int =
   if fuel <= 0 then errors
   else if idx >= span_count then errors
   else let
@@ -321,6 +322,13 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
     val ss = span_start(spans, idx, span_max)
     val se = span_end(spans, idx, span_max)
   in
+    (* If skipping (inside non-matching target), blank everything except kind 11/12 *)
+    if $AR.gt_int_int(skip_target, 0) && ~$AR.eq_int_int(kind, 11) && ~$AR.eq_int_int(kind, 12) then let
+      val () = emit_blanks(src, ss, se, src_max, dats)
+      val () = emit_blanks(src, ss, se, src_max, sats)
+    in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
+                  sats, dats, build_target, is_unsafe, errors, skip_target, fuel - 1) end
+    else
     (* kind=0: passthrough *)
     if $AR.eq_int_int(kind, 0) then let
       val fuel2 = $AR.checked_nat(se - ss + 1)
@@ -337,7 +345,7 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
                   emit_blanks(src, ss, se, src_max, dats)
                 else ())
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, skip_target, fuel - 1) end
 
     (* kind=1: hash_use - emit aliased staload in dats, blank in sats *)
     else if $AR.eq_int_int(kind, 1) then let
@@ -345,7 +353,7 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
       (* In dats: emit staload ALIAS = "pkg/src/lib.sats" at the #use position *)
       val () = emit_dep_staload_sats(src, src_max, spans, idx, span_max, dats)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, skip_target, fuel - 1) end
 
     (* kind=2: pub_decl - content to sats, blanks to dats *)
     else if $AR.eq_int_int(kind, 2) then let
@@ -359,7 +367,7 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
       (* Blank everything in dats *)
       val () = emit_blanks(src, ss, se, src_max, dats)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, skip_target, fuel - 1) end
 
     (* kind=3: qualified_access - emit $alias.member respecting dest *)
     else if $AR.eq_int_int(kind, 3) then let
@@ -370,7 +378,7 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
                   emit_qualified(src, src_max, spans, idx, span_max, sats)
                 else ())
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, skip_target, fuel - 1) end
 
     (* kind=4: unsafe_block - emit contents if unsafe=true, error if unsafe=false *)
     else if $AR.eq_int_int(kind, 4) then
@@ -389,7 +397,7 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
         val () = emit_blanks(src, ce, se, src_max, dats)
         val () = emit_blanks(src, ce, se, src_max, sats)
       in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                    sats, dats, build_target, is_unsafe, errors, skip_target, fuel - 1) end
       else let
         val () = println! ("error: $UNSAFE block at line ", _byte_to_line(src, ss, src_max), " column ", _byte_to_col(src, ss, src_max), " not allowed in safe package")
         val () = emit_blanks(src, ss, se, src_max, dats)
@@ -411,14 +419,14 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
       val () = emit_range(src, ss, se, src_max, dats, fuel2)
       val () = emit_blanks(src, ss, se, src_max, sats)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, skip_target, fuel - 1) end
 
     (* kind=7: target_decl - blank everything *)
     else if $AR.eq_int_int(kind, 7) then let
       val () = emit_blanks(src, ss, se, src_max, sats)
       val () = emit_blanks(src, ss, se, src_max, dats)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, skip_target, fuel - 1) end
 
     (* kind=8: unittest_block - emit contents in test mode, blank otherwise *)
     else if $AR.eq_int_int(kind, 8) then let
@@ -439,7 +447,7 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
         val () = emit_blanks(src, ss, se, src_max, dats)
       in end)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, skip_target, fuel - 1) end
 
     (* kind=9: restricted_keyword — same as kind 5, always error *)
     else if $AR.eq_int_int(kind, 9) then let
@@ -468,38 +476,31 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
         val () = emit_blanks(src, ss, se, src_max, dats)
       in end)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, skip_target, fuel - 1) end
 
-    (* kind=11: target_block - emit contents only if build_target matches *)
+    (* kind=11: target begin marker - blank marker, set skip if non-matching *)
     else if $AR.eq_int_int(kind, 11) then let
       val block_target = span_aux1(spans, idx, span_max)
-      val cs = span_aux2(spans, idx, span_max)
-      val ce = span_aux3(spans, idx, span_max)
       val matches = $AR.eq_int_int(block_target, build_target)
-    in
-      if matches then let
-        (* Target matches: emit content, blank markers *)
-        val () = emit_blanks(src, ss, cs, src_max, dats)
-        val () = emit_blanks(src, ss, cs, src_max, sats)
-        val fuel2 = $AR.checked_nat(ce - cs + 1)
-        val () = emit_range(src, cs, ce, src_max, dats, fuel2)
-        val () = emit_blanks(src, cs, ce, src_max, sats)
-        val () = emit_blanks(src, ce, se, src_max, dats)
-        val () = emit_blanks(src, ce, se, src_max, sats)
-      in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors, fuel - 1) end
-      else let
-        (* Target doesn't match: blank everything *)
-        val () = emit_blanks(src, ss, se, src_max, sats)
-        val () = emit_blanks(src, ss, se, src_max, dats)
-      in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+      val () = emit_blanks(src, ss, se, src_max, dats)
+      val () = emit_blanks(src, ss, se, src_max, sats)
+      val new_skip = (if matches then 0 else 1): int
+    in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
+                  sats, dats, build_target, is_unsafe, errors, new_skip, fuel - 1) end
+
+    (* kind=12: target end marker - blank marker, clear skip *)
+    else if $AR.eq_int_int(kind, 12) then let
+      val () = emit_blanks(src, ss, se, src_max, dats)
+      val () = emit_blanks(src, ss, se, src_max, sats)
+    in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
+                  sats, dats, build_target, is_unsafe, errors, 0, fuel - 1) end
     end
 
     (* Unknown kind: skip *)
-    else
+    else (
       emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1)
+                  sats, dats, build_target, is_unsafe, errors, skip_target, fuel - 1)
+    )
   end
 
 (* Build dats prelude: self-staload + dependency staloads *)
@@ -584,7 +585,7 @@ implement do_emit (src, src_len, src_max, spans, span_max, span_count, build_tar
 
   (* Emit all spans *)
   val emit_errors = emit_spans(src, src_max, spans, span_max, span_count, 0,
-    sats_b, dats_b, build_target, is_unsafe, 0, $AR.checked_nat(span_count + 1))
+    sats_b, dats_b, build_target, is_unsafe, 0, 0, $AR.checked_nat(span_count + 1))
 
   (* Rename the entry point function in the .dats output *)
   val @(dats_tmp, dats_tmp_len) = $B.to_arr(dats_b)

--- a/src/lexer.bats
+++ b/src/lexer.bats
@@ -766,13 +766,18 @@ fn lex_target_decl {l:agz}{n:pos}
   val p1 = skip_ws(src, ident_end, max, 256)
 in
   if looking_at_begin(src, p1, max) then let
-    (* Block form: find matching end, store content range *)
+    (* Block form: emit begin marker, lex content recursively, emit end marker *)
     val contents_start = p1 + 5
     val end_pos = find_end_kw(src, contents_start, src_len, max, 1, $AR.checked_nat(src_len))
     val ep = (if end_pos < src_len then end_pos + 3 else end_pos): int
-    (* kind=11: target_block. aux1=target(0=native,1=wasm), aux2/aux3=content range *)
-    val () = put_span(spans, 11, 0, start, ep, target, contents_start, end_pos, 0)
-  in @(ep, count + 1) end
+    (* kind=11: target begin. aux1=target. Covers "#target X begin" *)
+    val () = put_span(spans, 11, 0, start, contents_start, target, 0, 0, 0)
+    (* Recursively lex content with src_len=end_pos so lex_main stops there *)
+    val @(_, inner_count) = lex_main(src, end_pos, max, spans, contents_start, count + 1,
+      $AR.checked_nat(end_pos + 1))
+    (* kind=12: target end. aux1=target. Covers "end" *)
+    val () = put_span(spans, 12, 0, end_pos, ep, target, 0, 0, 0)
+  in @(ep, inner_count + 1) end
   else let
     (* Line form: just the directive *)
     val ep = skip_to_eol(src, ident_end, src_len, max, $AR.checked_nat(src_len))


### PR DESCRIPTION
## Summary
- Lexer creates begin/end markers for #target blocks, recursively lexes content
- $UNSAFE begin...end inside #target blocks are now properly processed
- Emitter tracks skip_target depth for non-matching target blocks

## Context
Bridge modules have $UNSAFE begin...end inside #target wasm begin...end.
Without recursive lexing, $UNSAFE text passed through literally in WASM builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)