### PR TITLE
Fix: passthrough staload to both .sats and .dats

### DIFF
--- a/src/lexer.bats
+++ b/src/lexer.bats
@@ -990,7 +990,16 @@ fun lex_main {l:agz}{n:pos}{fuel:nat} .<fuel>.
     (* Default: passthrough *)
     else let
       val ep = lex_passthrough_scan(src, pos + 1, src_len, max, $AR.checked_nat(src_len))
-      val () = put_span(spans, 0, 0, pos, ep, 0, 0, 0, 0)
+      (* staload lines should go to both .sats and .dats *)
+      val dest = (if $AR.eq_int_int(b0, 115) &&
+         $AR.eq_int_int(b1, 116) &&
+         $AR.eq_int_int($S.borrow_byte(src, pos + 2, max), 97) &&
+         $AR.eq_int_int($S.borrow_byte(src, pos + 3, max), 108) &&
+         $AR.eq_int_int($S.borrow_byte(src, pos + 4, max), 111) &&
+         $AR.eq_int_int($S.borrow_byte(src, pos + 5, max), 97) &&
+         $AR.eq_int_int($S.borrow_byte(src, pos + 6, max), 100)
+       then 2 else 0): int
+      val () = put_span(spans, 0, dest, pos, ep, 0, 0, 0, 0)
     in lex_main(src, src_len, max, spans, ep, count + 1, fuel - 1) end
   end
 


### PR DESCRIPTION
Makes shared module exports visible in .sats.