### PR TITLE
Fix emitter .bats→.sats transformation corrupting string literals

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,35 +24,33 @@ jobs:
           mkdir -p ~/.bats
           ln -sf ~/.ats2/ATS2-Postiats-int-0.4.2 ~/.bats/ats2
 
-      - name: Cache bats compiler
-        id: cache-bats
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache bootstrap compiler
+        id: cache-bootstrap
         uses: actions/cache@v4
         with:
-          path: ~/bats-bin
-          key: bats-from-c-v1-${{ runner.os }}-${{ hashFiles('.github/workflows/check.yml') }}
+          path: ~/bootstrap
+          key: bootstrap-v2-${{ runner.os }}-${{ hashFiles('.github/workflows/check.yml') }}
 
-      - name: Build bats from C
-        if: steps.cache-bats.outputs.cache-hit != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Build bootstrap compiler
+        if: steps.cache-bootstrap.outputs.cache-hit != 'true'
         run: |
-          RUN_ID=$(gh run list --repo bats-lang/bats --branch main --status success --workflow check --limit 1 --json databaseId --jq '.[0].databaseId')
-          gh run download "$RUN_ID" --repo bats-lang/bats --name bats-c --dir ~/bats-c
-          cd ~/bats-c
-          make PATSHOME=$HOME/.ats2/ATS2-Postiats-int-0.4.2
-          mkdir -p ~/bats-bin
-          cp debug/bats ~/bats-bin/bats
+          git clone https://github.com/bats-lang/bats-old.git ~/bootstrap
+          cd ~/bootstrap
+          cargo build --release
 
       - name: bats check
         run: |
-          export PATH=~/bats-bin:$PATH
+          export PATH=~/bootstrap/target/release:$PATH
           git clone https://github.com/bats-lang/repository-prototype.git ~/repository
           bats lock --repository ~/repository
           bats check --repository ~/repository
 
       - name: bats build
         run: |
-          export PATH=~/bats-bin:$PATH
+          export PATH=~/bootstrap/target/release:$PATH
           bats build --repository ~/repository
 
       - name: bats build --to-c

--- a/src/emitter.bats
+++ b/src/emitter.bats
@@ -84,9 +84,19 @@ fn span_aux4 {l:agz}{n:pos}
    Emitter: copy source range to builder, count newlines
    ============================================================ *)
 
-(* Copy bytes from source borrow to builder.
-   Transforms .bats" → .sats" in staload paths. *)
+(* Copy bytes from source borrow to builder. *)
 fun emit_range {ls:agz}{ns:pos}{fuel:nat} .<fuel>.
+  (src: !$A.borrow(byte, ls, ns), start: int, end_pos: int,
+   max: int ns, out: !$B.builder0, fuel: int fuel): void =
+  if fuel <= 0 then ()
+  else if start >= end_pos then ()
+  else let
+    val b = $S.borrow_byte(src, start, max)
+    val () = $B.put_byte_safe(out, b)
+  in emit_range(src, start + 1, end_pos, max, out, fuel - 1) end
+
+(* Copy bytes, transforming .bats" → .sats" for staload paths. *)
+fun emit_range_staload {ls:agz}{ns:pos}{fuel:nat} .<fuel>.
   (src: !$A.borrow(byte, ls, ns), start: int, end_pos: int,
    max: int ns, out: !$B.builder0, fuel: int fuel): void =
   if fuel <= 0 then ()
@@ -102,7 +112,7 @@ fun emit_range {ls:agz}{ns:pos}{fuel:nat} .<fuel>.
       $AR.eq_int_int($S.borrow_byte(src, start + 4, max), 34)
     then 115 else b): int
     val () = $B.put_byte_safe(out, b_out)
-  in emit_range(src, start + 1, end_pos, max, out, fuel - 1) end
+  in emit_range_staload(src, start + 1, end_pos, max, out, fuel - 1) end
 
 (* Count newlines in source range, emit that many newlines *)
 fun emit_blanks_count {ls:agz}{ns:pos}{fuel:nat} .<fuel>.
@@ -599,6 +609,14 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
       in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
                     sats, dats, build_target, is_unsafe, errors, fuel - 1) end
     end
+
+    (* kind=12: staload_line - emit to both with .bats→.sats rename *)
+    else if $AR.eq_int_int(kind, 12) then let
+      val fuel2 = $AR.checked_nat(se - ss + 1)
+      val () = emit_range_staload(src, ss, se, src_max, dats, fuel2)
+      val () = emit_range_staload(src, ss, se, src_max, sats, fuel2)
+    in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
+                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
 
     (* Unknown kind: skip *)
     else

--- a/src/lexer.bats
+++ b/src/lexer.bats
@@ -904,7 +904,7 @@ fun lex_main {l:agz}{n:pos}{fuel:nat} .<fuel>.
       val ep = pos + 6
       val () = put_span(spans, 5, 0, pos, ep, 0, 0, 0, 0)
     in lex_main(src, src_len, max, spans, ep, count + 1, fuel - 1) end
-    (* staload lines go to both .sats and .dats as a single span *)
+    (* staload lines: kind=12, go to both .sats and .dats with .bats→.sats rename *)
     else if $AR.eq_int_int(b0, 115) &&
        $AR.eq_int_int(b1, 116) &&
        $AR.eq_int_int($S.borrow_byte(src, pos + 2, max), 97) &&
@@ -913,21 +913,23 @@ fun lex_main {l:agz}{n:pos}{fuel:nat} .<fuel>.
        $AR.eq_int_int($S.borrow_byte(src, pos + 5, max), 97) &&
        $AR.eq_int_int($S.borrow_byte(src, pos + 6, max), 100) then let
       val ep = skip_to_eol(src, pos + 7, src_len, max, $AR.checked_nat(src_len))
-      val () = put_span(spans, 0, 2, pos, ep, 0, 0, 0, 0)
+      val () = put_span(spans, 12, 2, pos, ep, 0, 0, 0, 0)
     in lex_main(src, src_len, max, spans, ep, count + 1, fuel - 1) end
     (* Default: passthrough *)
     else let
       val ep = lex_passthrough_scan(src, pos + 1, src_len, max, $AR.checked_nat(src_len))
-      (* staload lines should go to both .sats and .dats *)
-      val dest = (if $AR.eq_int_int(b0, 115) &&
+      (* staload lines use kind=12 for .bats→.sats rename *)
+      val is_staload = (if $AR.eq_int_int(b0, 115) &&
          $AR.eq_int_int(b1, 116) &&
          $AR.eq_int_int($S.borrow_byte(src, pos + 2, max), 97) &&
          $AR.eq_int_int($S.borrow_byte(src, pos + 3, max), 108) &&
          $AR.eq_int_int($S.borrow_byte(src, pos + 4, max), 111) &&
          $AR.eq_int_int($S.borrow_byte(src, pos + 5, max), 97) &&
          $AR.eq_int_int($S.borrow_byte(src, pos + 6, max), 100)
-       then 2 else 0): int
-      val () = put_span(spans, 0, dest, pos, ep, 0, 0, 0, 0)
+       then true else false): bool
+      val kind = (if is_staload then 12 else 0): int
+      val dest = (if is_staload then 2 else 0): int
+      val () = put_span(spans, kind, dest, pos, ep, 0, 0, 0, 0)
     in lex_main(src, src_len, max, spans, ep, count + 1, fuel - 1) end
   end
 


### PR DESCRIPTION
## Summary

- Split `emit_range` into raw copy (general code) and `emit_range_staload` (staload lines only)
- Added span kind=12 in lexer to identify staload lines for targeted transformation
- Temporarily reverts CI to bats-old bootstrap to produce correct bats-c artifact

The old `emit_range` globally replaced `.bats"` → `.sats"` in ALL emitted text, corrupting string literals like `has_suffix(e, el, 256, ".bats", 5)` in the resolver. This broke `bats lock` for all downstream packages when the self-hosting compiler was used.

## Test plan

- [ ] CI passes with bats-old bootstrap
- [ ] After merge, follow-up PR switches CI back to bats-c (which will now be correct)
- [ ] PWA and other downstream CIs pass with the new bats-c artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)