### PR TITLE
Run both native and WASM passes in bats check

### DIFF
--- a/src/commands.bats
+++ b/src/commands.bats
@@ -1139,6 +1139,7 @@ end
 
 implement do_check() = let
   val () = do_build(0, 0)
+  val () = do_build(0, 1)
   val () = println! ("  process: check passed")
   val () = println! ("  exit code: 0")
 in


### PR DESCRIPTION
## Summary
- `do_check` now calls `do_build(0, 1)` after `do_build(0, 0)` to type-check WASM-target binaries
- Previously, WASM binaries (files starting with `#target wasm binary`) were silently skipped during `bats check`

Fixes #102

## Test plan
- [x] `bats check` passes locally (single-target native project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)