### PR TITLE
Fix #target wasm begin/end to properly lex inner content

### DIFF
--- a/src/emitter.bats
+++ b/src/emitter.bats
@@ -502,7 +502,8 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
    spans: !$A.borrow(byte, lp, np), span_max: int np,
    span_count: int, idx: int,
    sats: !$B.builder_v >> $B.builder_v, dats: !$B.builder_v >> $B.builder_v,
-   build_target: int, is_unsafe: int, errors: int, fuel: int fuel): int =
+   build_target: int, is_unsafe: int, errors: int,
+   target_state: int, fuel: int fuel): int =
   if fuel <= 0 then errors
   else if idx >= span_count then errors
   else let
@@ -511,8 +512,34 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
     val ss = span_start(spans, idx, span_max)
     val se = span_end(spans, idx, span_max)
   in
+    (* kind=13: target_begin - update target state *)
+    if $AR.eq_int_int(kind, 13) then let
+      val block_target = span_aux1(spans, idx, span_max)
+      val () = emit_blanks_v(src, ss, se, src_max, sats)
+      val () = emit_blanks_v(src, ss, se, src_max, dats)
+      val new_ts = (if target_state > 0 then target_state + 1
+                    else if $AR.eq_int_int(block_target, build_target) then 0
+                    else 1): int
+    in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
+                  sats, dats, build_target, is_unsafe, errors, new_ts, fuel - 1) end
+
+    (* kind=14: target_end - restore target state *)
+    else if $AR.eq_int_int(kind, 14) then let
+      val () = emit_blanks_v(src, ss, se, src_max, sats)
+      val () = emit_blanks_v(src, ss, se, src_max, dats)
+      val new_ts = (if target_state > 0 then target_state - 1 else 0): int
+    in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
+                  sats, dats, build_target, is_unsafe, errors, new_ts, fuel - 1) end
+
+    (* Inside non-matching target block: blank everything *)
+    else if target_state > 0 then let
+      val () = emit_blanks_v(src, ss, se, src_max, sats)
+      val () = emit_blanks_v(src, ss, se, src_max, dats)
+    in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
+                  sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
+
     (* kind=0: passthrough *)
-    if $AR.eq_int_int(kind, 0) then let
+    else if $AR.eq_int_int(kind, 0) then let
       val () = (if $AR.eq_int_int(dest, 0) || $AR.eq_int_int(dest, 2) then
                   emit_range_v(src, ss, se, src_max, dats)
                 else ())
@@ -526,7 +553,7 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
                   emit_blanks_v(src, ss, se, src_max, dats)
                 else ())
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
 
     (* kind=1: hash_use - emit aliased staload in dats, blank in sats *)
     else if $AR.eq_int_int(kind, 1) then let
@@ -534,7 +561,7 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
       (* In dats: emit staload ALIAS = "pkg/src/lib.sats" at the #use position *)
       val () = emit_dep_stld_sats(src, src_max, spans, idx, span_max, dats)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
 
     (* kind=2: pub_decl - content to sats, blanks to dats *)
     else if $AR.eq_int_int(kind, 2) then let
@@ -547,7 +574,7 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
       (* Blank everything in dats *)
       val () = emit_blanks_v(src, ss, se, src_max, dats)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
 
     (* kind=3: qualified_access - emit $alias.member respecting dest *)
     else if $AR.eq_int_int(kind, 3) then let
@@ -558,7 +585,7 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
                   emit_qualified(src, src_max, spans, idx, span_max, sats)
                 else ())
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
 
     (* kind=4: unsafe_block - emit contents if unsafe=true, error if unsafe=false *)
     else if $AR.eq_int_int(kind, 4) then
@@ -576,13 +603,13 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
         val () = emit_blanks_v(src, ce, se, src_max, dats)
         val () = emit_blanks_v(src, ce, se, src_max, sats)
       in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                    sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
       else let
         val () = println! ("error: $UNSAFE block at line ", _byte_to_line(src, ss, src_max), " column ", _byte_to_col(src, ss, src_max), " not allowed in safe package")
         val () = emit_blanks_v(src, ss, se, src_max, dats)
         val () = emit_blanks_v(src, ss, se, src_max, sats)
       in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors + 1, fuel - 1) end
+                    sats, dats, build_target, is_unsafe, errors + 1, target_state, fuel - 1) end
 
     (* kind=5: unsafe_construct outside $UNSAFE block — always error *)
     else if $AR.eq_int_int(kind, 5) then let
@@ -590,21 +617,21 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
       val () = emit_blanks_v(src, ss, se, src_max, dats)
       val () = emit_blanks_v(src, ss, se, src_max, sats)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors + 1, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors + 1, target_state, fuel - 1) end
 
     (* kind=6: extcode_block - emit as-is to dats *)
     else if $AR.eq_int_int(kind, 6) then let
       val () = emit_range_v(src, ss, se, src_max, dats)
       val () = emit_blanks_v(src, ss, se, src_max, sats)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
 
     (* kind=7: target_decl - blank everything *)
     else if $AR.eq_int_int(kind, 7) then let
       val () = emit_blanks_v(src, ss, se, src_max, sats)
       val () = emit_blanks_v(src, ss, se, src_max, dats)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
 
     (* kind=8: unittest_block - emit contents in test mode, blank otherwise *)
     else if $AR.eq_int_int(kind, 8) then let
@@ -620,12 +647,12 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
         val () = emit_blanks_v(src, ce, se, src_max, dats)
         val () = emit_blanks_v(src, ss, se, src_max, sats)
       in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                    sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
       else let
         val () = emit_blanks_v(src, ss, se, src_max, sats)
         val () = emit_blanks_v(src, ss, se, src_max, dats)
       in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                    sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
     end
 
     (* kind=9: restricted_keyword — same as kind 5, always error *)
@@ -634,7 +661,7 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
       val () = emit_blanks_v(src, ss, se, src_max, dats)
       val () = emit_blanks_v(src, ss, se, src_max, sats)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors + 1, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors + 1, target_state, fuel - 1) end
 
     (* kind=10: unittest_run - emit contents in test mode, blank otherwise *)
     else if $AR.eq_int_int(kind, 10) then let
@@ -650,37 +677,12 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
         val () = emit_blanks_v(src, ce, se, src_max, dats)
         val () = emit_blanks_v(src, ss, se, src_max, sats)
       in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                    sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
       else let
         val () = emit_blanks_v(src, ss, se, src_max, sats)
         val () = emit_blanks_v(src, ss, se, src_max, dats)
       in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors, fuel - 1) end
-    end
-
-    (* kind=11: target_block - emit contents only if build_target matches *)
-    else if $AR.eq_int_int(kind, 11) then let
-      val block_target = span_aux1(spans, idx, span_max)
-      val cs = span_aux2(spans, idx, span_max)
-      val ce = span_aux3(spans, idx, span_max)
-      val matches = $AR.eq_int_int(block_target, build_target)
-    in
-      if matches then let
-        (* Target matches: emit content, blank markers *)
-        val () = emit_blanks_v(src, ss, cs, src_max, dats)
-        val () = emit_blanks_v(src, ss, cs, src_max, sats)
-        val () = emit_range_process_unsafe_v(src, cs, ce, ce, src_max, dats)
-        val () = emit_blanks_v(src, cs, ce, src_max, sats)
-        val () = emit_blanks_v(src, ce, se, src_max, dats)
-        val () = emit_blanks_v(src, ce, se, src_max, sats)
-      in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors, fuel - 1) end
-      else let
-        (* Target doesn't match: blank everything *)
-        val () = emit_blanks_v(src, ss, se, src_max, sats)
-        val () = emit_blanks_v(src, ss, se, src_max, dats)
-      in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                    sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                    sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
     end
 
     (* kind=12: staload_line - emit to both with .bats→.sats rename *)
@@ -688,12 +690,12 @@ fun emit_spans {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
       val () = emit_range_stald_v(src, ss, se, src_max, dats)
       val () = emit_range_stald_v(src, ss, se, src_max, sats)
     in emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1) end
+                  sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1) end
 
     (* Unknown kind: skip *)
     else
       emit_spans(src, src_max, spans, span_max, span_count, idx + 1,
-                  sats, dats, build_target, is_unsafe, errors, fuel - 1)
+                  sats, dats, build_target, is_unsafe, errors, target_state, fuel - 1)
   end
 
 (* Build dats prelude: self-stld + dependency staloads *)
@@ -776,7 +778,7 @@ implement do_emit (src, src_len, src_max, spans, span_max, span_count, build_tar
 
   (* Emit all spans *)
   val emit_errors = emit_spans(src, src_max, spans, span_max, span_count, 0,
-    sats_b, dats_b, build_target, is_unsafe, 0, 524288)
+    sats_b, dats_b, build_target, is_unsafe, 0, 0, 524288)
 
   (* Rename the entry point function in the .dats output *)
   val @(dats_tmp, dats_tmp_len) = $B.to_arr(dats_b)

--- a/src/lexer.bats
+++ b/src/lexer.bats
@@ -32,6 +32,8 @@ fn is_ident_start(b: int): bool =
    Kinds: 0=passthrough 1=hash_use 2=pub_decl 3=qualified
           4=unsafe_block 5=unsafe_construct 6=extcode
           7=target 8=unittest 9=restricted 10=unittest_run
+          11=target_block (opaque, expanded by post-lex pass)
+          13=target_begin 14=target_end
    Dests: 0=dats 1=sats 2=both
    ============================================================ *)
 
@@ -929,6 +931,75 @@ fun lex_main {l:agz}{n:pos}{fuel:nat} .<fuel>.
     in lex_main(src, src_len, max, spans, ep, count + 1, fuel - 1) end
   end
 
+(* ============================================================
+   Post-lex expansion: expand kind=11 target blocks
+   Replaces opaque target_block spans with target_begin (kind=13),
+   properly-lexed inner spans, and target_end (kind=14).
+   ============================================================ *)
+
+fn _get_i32 {l:agz}{n:pos}
+  (bv: !$A.borrow(byte, l, n), off: int, max: int n): int =
+  let
+    val b0 = $S.borrow_byte(bv, off, max)
+    val b1 = $S.borrow_byte(bv, off + 1, max)
+    val b2 = $S.borrow_byte(bv, off + 2, max)
+    val b3 = $S.borrow_byte(bv, off + 3, max)
+  in b0 + b1 * 256 + b2 * 65536 + b3 * 16777216 end
+
+(* Check if any kind=11 spans exist *)
+fun _has_target_blocks {l:agz}{n:pos}{fuel:nat} .<fuel>.
+  (spans: !$A.borrow(byte, l, n), max: int n,
+   span_count: int, idx: int, fuel: int fuel): bool =
+  if fuel <= 0 then false
+  else if idx >= span_count then false
+  else if $AR.eq_int_int($S.borrow_byte(spans, idx * 28, max), 11) then true
+  else _has_target_blocks(spans, max, span_count, idx + 1, fuel - 1)
+
+(* Copy one 28-byte span record from borrow to builder *)
+fun _copy_span_bytes {l:agz}{n:pos}{fuel:nat} .<fuel>.
+  (spans: !$A.borrow(byte, l, n), base: int, max: int n,
+   out: !$B.builder_v >> $B.builder_v, byte_idx: int, fuel: int fuel): void =
+  if fuel <= 0 then ()
+  else if byte_idx >= 28 then ()
+  else let
+    val b = $S.borrow_byte(spans, base + byte_idx, max)
+    val () = put_char_v(out, b)
+  in _copy_span_bytes(spans, base, max, out, byte_idx + 1, fuel - 1) end
+
+(* Expand target blocks: replace kind=11 with kind=13 + inner spans + kind=14 *)
+fun _expand_target_blocks {ls:agz}{ns:pos}{lp:agz}{np:pos}{fuel:nat} .<fuel>.
+  (src: !$A.borrow(byte, ls, ns), src_len: int, max: int ns,
+   spans: !$A.borrow(byte, lp, np), span_max: int np,
+   span_count: int, idx: int,
+   out: !$B.builder_v >> $B.builder_v,
+   new_count: int, fuel: int fuel): int =
+  if fuel <= 0 then new_count
+  else if idx >= span_count then new_count
+  else let
+    val kind = $S.borrow_byte(spans, idx * 28, span_max)
+  in
+    if $AR.eq_int_int(kind, 11) then let
+      val base = idx * 28
+      val ss = _get_i32(spans, base + 2, span_max)
+      val se = _get_i32(spans, base + 6, span_max)
+      val block_target = _get_i32(spans, base + 10, span_max)
+      val cs = _get_i32(spans, base + 14, span_max)
+      val ce = _get_i32(spans, base + 18, span_max)
+      (* Emit target_begin marker: kind=13, covers [ss, cs) *)
+      val () = put_span(out, 13, 0, ss, cs, block_target, 0, 0, 0)
+      (* Lex inner content: use ce as src_len bound *)
+      val @(_, inner_count) = lex_main(src, ce, max, out, cs, 0, max)
+      (* Emit target_end marker: kind=14, covers [ce, se) *)
+      val () = put_span(out, 14, 0, ce, se, 0, 0, 0, 0)
+    in _expand_target_blocks(src, src_len, max, spans, span_max,
+         span_count, idx + 1, out, new_count + inner_count + 2, fuel - 1) end
+    else let
+      (* Non-target span: copy 28 bytes as-is *)
+      val () = _copy_span_bytes(spans, idx * 28, span_max, out, 0, 28)
+    in _expand_target_blocks(src, src_len, max, spans, span_max,
+         span_count, idx + 1, out, new_count + 1, fuel - 1) end
+  end
+
 (* Top-level lex function *)
 #pub fn do_lex {l:agz}{n:pos}
   (src: !$A.borrow(byte, l, n), src_len: int, max: int n
@@ -938,4 +1009,18 @@ implement do_lex (src, src_len, max) = let
   var span_builder = $B.create()
   val @(_, span_count) = lex_main(src, src_len, max, span_builder, 0, 0, max)
   val @(span_arr, span_arr_len) = $B.to_arr(span_builder)
-in @(span_arr, span_arr_len, span_count) end
+  val @(fz, bv) = $A.freeze<byte>(span_arr)
+in
+  if _has_target_blocks(bv, 524288, span_count, 0, max) then let
+    var expanded = $B.create()
+    val new_count = _expand_target_blocks(src, src_len, max, bv, 524288,
+      span_count, 0, expanded, 0, max)
+    val () = $A.drop<byte>(fz, bv)
+    val () = $A.free<byte>($A.thaw<byte>(fz))
+    val @(exp_arr, exp_arr_len) = $B.to_arr(expanded)
+  in @(exp_arr, exp_arr_len, new_count) end
+  else let
+    val () = $A.drop<byte>(fz, bv)
+    val arr = $A.thaw<byte>(fz)
+  in @(arr, span_arr_len, span_count) end
+end


### PR DESCRIPTION
## Summary
- The lexer was treating `#target wasm begin...end` as an opaque span, causing the emitter to dump raw `#pub fun` syntax into .dats (parse errors) and blank .sats entirely (missing declarations)
- Added a post-lex expansion pass that re-lexes target block content through `lex_main`, replacing the opaque span with `target_begin`/`target_end` markers and properly-lexed inner spans
- The emitter now tracks `target_state` to blank all spans inside non-matching target blocks while processing matching blocks normally

## Test plan
- [x] `bats check` passes (patsopt type-checks all modules)
- [x] `bats build` succeeds (self-hosting compiler builds)
- [x] Quire WASM build succeeds with `#target wasm begin/end` wrapped modules
- [x] Quire native build type-checks successfully (blanked modules produce no patsopt errors)
- [x] Generated reader.sats contains `fun` declarations for WASM target
- [x] Generated reader.sats/dats are blank (except preludes) for native target

🤖 Generated with [Claude Code](https://claude.com/claude-code)